### PR TITLE
Added 2 new unit converstions

### DIFF
--- a/lib/step.rb
+++ b/lib/step.rb
@@ -1,3 +1,4 @@
+# coding: iso-8859-1
 require 'fileutils'
 
 module CMORizer
@@ -215,8 +216,26 @@ module CMORizer
           when ["K", "degC"]
             cmds << CDO_SUBC_cmd.new(-273.15)
           when ["mmolC/m2/d", "kg m-2 s-1"]
+            # notes on how this factor was derived (by chrisdane "Christopher Danek")
+            # e.g. recom variable: CO2f => CMIP6_Omon.json: fgco2
+            # 1) mmolC -> molC: /1e3
+            # 2) molC -> gC: *12.0107
+            # 3) gC -> kgC: /1e3
+            # 4) d-1 -> s-1: /86400
+            # -> mult_factor = 1/1e3*12.0107/1e3/86400 # = 1.390127e-10
+            # In the CMIP6_Omon.json:fgco2 case, an additional sign change is necessary:
+            # >0: into ocean -> >0: into atm: *-1
+            # -> mult_factor = mult_factor*-1
             cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
           when ["uatm", "Pa"]
+            # notes on how this factor was derived (by chrisdane "Christopher Danek")
+            # e.g. recom variable: pCO2s => CMIP6_Omon.json: spco2
+            # 1) µatm -> atm: /1e6
+            # 2) atm -> Pa: *1.01325e5 (1 atm = 1.01325e5 Pa)
+            # -> mult_factor = 1/1e6*1.01325e5 # = 0.101325
+            #
+            # these notes are available on the following link
+            # https://notes.desy.de/F8hTyk3PRielZrVdZRtyaQ?view#Seamore-missing-features-FESOM1-and-2
             cmd << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -214,6 +214,10 @@ module CMORizer
             cmds << CDO_MULC_cmd.new(100)
           when ["K", "degC"]
             cmds << CDO_SUBC_cmd.new(-273.15)
+          when ["mmolC/m2/d", "kg m-2 s-1"]
+            cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
+          when ["uatm", "Pa"]
+            cmd << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"
           end          

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -236,7 +236,7 @@ module CMORizer
             #
             # these notes are available on the following link
             # https://notes.desy.de/F8hTyk3PRielZrVdZRtyaQ?view#Seamore-missing-features-FESOM1-and-2
-            cmd << CDO_MULC_cmd.new(0.101325)
+            cmds << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"
           end          

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -226,7 +226,8 @@ module CMORizer
             # In the CMIP6_Omon.json:fgco2 case, an additional sign change is necessary:
             # >0: into ocean -> >0: into atm: *-1
             # -> mult_factor = mult_factor*-1
-            cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
+            # COMMENT: For sign change use flip_sign function 
+            cmds << CDO_MULC_cmd.new(1.390127e-10)
           when ["uatm", "Pa"]
             # notes on how this factor was derived (by chrisdane "Christopher Danek")
             # e.g. recom variable: pCO2s => CMIP6_Omon.json: spco2


### PR DESCRIPTION
Auto-unit converstions for recom variables CO2f and pCO2s are added.
The negative sign used in "mmolC/m2/d" -> "kg m-2 s-1" is to correct the sign change for into ocean or into atm.