### PR TITLE
Docs with YARD

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,9 @@ jobs:
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          artifact-name: site
+          path: _site
   # Deployment job
   deploy:
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,26 +1,21 @@
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
-
 on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main", "feat/yard", "**doc**"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
 jobs:
   # Build job
   build:
@@ -31,7 +26,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Setup Ruby
-        uses: uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
       - name: Install dependencies
         run: |
           gem install bundler
@@ -48,8 +43,7 @@ jobs:
           source: ./
           destination: ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3 
-
+        uses: actions/upload-pages-artifact@v3
   # Deployment job
   deploy:
     environment:
@@ -61,4 +55,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.2 # This is the Ruby version of DRKZ's Levante
       - name: Install dependencies
         run: |
           gem install bundler

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,12 +37,10 @@ jobs:
         run: |
           gem install yard
           yard doc
-          mkdir _site
-          mv doc _site/docs
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
-          source: ./
+          source: ./doc
           destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "feat/yard", "**doc**"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Setup Ruby
+        uses: uses: ruby/setup-ruby@v1
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+      - name: Generate YARD documentation
+        run: |
+          gem install yard
+          yard doc
+          mkdir _site
+          mv doc _site/docs
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3 
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,67 @@ lib/ruby/gems
 .paths
 build
 bin/ncn
+# Created by https://www.toptal.com/developers/gitignore/api/ruby
+# Edit at https://www.toptal.com/developers/gitignore?templates=ruby
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+# Gemfile.lock
+# .ruby-version
+# .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# Used by RuboCop. Remote config files pulled in from inherit_from directive.
+# .rubocop-https?--*
+
+# End of https://www.toptal.com/developers/gitignore/api/ruby
+
+.direnv/
+.envrc

--- a/lib/fesom_possible_var.rb
+++ b/lib/fesom_possible_var.rb
@@ -12,6 +12,23 @@ class FesomPossibleVar
   end
 
 
+  # Generates a collection of FesomPossibleVar objects based upon a FORTRAN code snippet
+  #
+  # Maps each line of the argument [String] code via a regex based upon the initialization of
+  # this class, using attributes <variable_id>, <description>, and <unit>.
+  #
+  # Special handling of the variable "tso", which uses TimeMethods::POINT instead of the
+  # default TimeMethods::Mean
+  #
+  # TODO(PG -- Reverse Engineering): I still need to find out of the regex **needs** the parameters
+  # or if instead it is used to **figure out what values they should have for initialization**.
+  #
+  # NOTE(PG -- Reverse Engineering): This looks like the Ruby equivalent of a Python `classmethod`
+  # and seems to implement an alternative way of constructing objects of this class.
+  #
+  # @param code [String] `FORTRAN` code to pare
+  # @param sort [Boolean] Whether or not to return the variables sorted (alphabetically?) by `variable_id`.
+  # @return [Array<FesomPossibleVar>] An array of FesomPossibleVar objects
   def self.create_from_fortran_code(code, sort: true)
     vars = code.split("\n").map do |init_line|
       /.+?, ['"](?<variable_id>[^,]+?)['"], ['"](?<description>.+?)['"], ['"](?<unit>[^,]+?)['"]\) *.*/ =~ init_line
@@ -30,7 +47,8 @@ class FesomPossibleVar
     end
   end
   
-  
+  # Helper method to nicely print out this FesomPossibleVar.
+  # @return [String]
   def to_s
     "#{@variable_id}: '#{@unit}' #{@time_method} '#{@description}'"
   end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,7 @@
 module Seamore
-  VERSION = '2.1.1' # version number according to semantic versioning (SemVer) paradigm
+  # The current version of the Seamore library following the semantic 
+  # versioning (SemVer) paradigm.
+  #
+  # @return [String] the current version of the Seamore library.
+  VERSION = '2.1.1'
 end


### PR DESCRIPTION
Similar to ReadTheDocs auto documentation, this provides a tool called [`yard`](https://yardoc.org) to automatically document the Ruby code. 

I would suggested some next steps:

- [ ] include usage documentation via this feature
- [ ] finish Ruby "doc-strings" for the rest of the code as I have only provided some examples.

A full specification of the syntax for the documentation comments can be found here: https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#docing

@siligam you can maybe merge this branch into yours and add documentation to your new features API using it. Usage pages for the end user can be added as well, see the section for files in https://rubydoc.info/gems/yard/file/docs/GettingStarted.md

> ## Linking Files `{file:...}`
> 
> Files can also be linked using this same syntax but by adding the file: prefix to the object name. Files refer to extra readme files you added via the command-line. Consider the following examples:
> ```
> {file:docs/GettingStarted.md Getting Started}
> {file:mypage.html#anchor Name}
> ```