### PR TITLE
Sanitize source text to avoid mis-treating variable names as Ruby Const

### DIFF
--- a/lib/cmorizer.rb
+++ b/lib/cmorizer.rb
@@ -32,7 +32,7 @@ module CMORizer
             new_txt << "#{varname} = '#{varname}'"
           end
         end
-      new_txt << line
+          new_txt << line
       end
       if requires_sanitization
         src_txt = new_txt.join("\n")

--- a/lib/cmorizer.rb
+++ b/lib/cmorizer.rb
@@ -15,10 +15,30 @@ module CMORizer
       @experiments = []
       @years_step = 1
       @eval_mode = true
+      src_txt = sanitize src_txt
       instance_eval(src_txt, src_txt)
       @eval_mode = false
     end
     
+    def sanitize(src_txt)
+  # Sanitizes the source text to avoid mistreating variable names as Ruby constants
+      new_txt = []
+      requires_sanitization = false
+      src_txt.each_line do |line|
+        if line.start_with?("cmorize ") && line.include("=>")
+          first, varname, *rest = line.split
+          if varname[0] =~ /[A-Z]/
+            requires_sanitization = true
+            new_txt << "#{varname} = '#{varname}'"
+          end
+        end
+      new_txt << line
+      end
+      if requires_sanitization
+        src_txt = new_txt.join("\n")
+      end
+      src_txt
+      end
   
     def execute(threadcount)
       @experiments.each do |experiment|

--- a/lib/cmorizer.rb
+++ b/lib/cmorizer.rb
@@ -25,7 +25,7 @@ module CMORizer
       new_txt = []
       requires_sanitization = false
       src_txt.each_line do |line|
-        if line.start_with?("cmorize ") && line.include("=>")
+        if line.start_with?("cmorize ") && line.include?("=>")
           first, varname, *rest = line.split
           if varname[0] =~ /[A-Z]/
             requires_sanitization = true

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -1,3 +1,4 @@
+# coding: iso-8859-1
 require 'fileutils'
 
 module CMORizer
@@ -215,8 +216,26 @@ module CMORizer
           when ["K", "degC"]
             cmds << CDO_SUBC_cmd.new(-273.15)
           when ["mmolC/m2/d", "kg m-2 s-1"]
+            # notes on how this factor was derived (by chrisdane "Christopher Danek")
+            # e.g. recom variable: CO2f => CMIP6_Omon.json: fgco2
+            # 1) mmolC -> molC: /1e3
+            # 2) molC -> gC: *12.0107
+            # 3) gC -> kgC: /1e3
+            # 4) d-1 -> s-1: /86400
+            # -> mult_factor = 1/1e3*12.0107/1e3/86400 # = 1.390127e-10
+            # In the CMIP6_Omon.json:fgco2 case, an additional sign change is necessary:
+            # >0: into ocean -> >0: into atm: *-1
+            # -> mult_factor = mult_factor*-1
             cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
           when ["uatm", "Pa"]
+            # notes on how this factor was derived (by chrisdane "Christopher Danek")
+            # e.g. recom variable: pCO2s => CMIP6_Omon.json: spco2
+            # 1) µatm -> atm: /1e6
+            # 2) atm -> Pa: *1.01325e5 (1 atm = 1.01325e5 Pa)
+            # -> mult_factor = 1/1e6*1.01325e5 # = 0.101325
+            #
+            # these notes are available on the following link
+            # https://notes.desy.de/F8hTyk3PRielZrVdZRtyaQ?view#Seamore-missing-features-FESOM1-and-2
             cmd << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -214,6 +214,10 @@ module CMORizer
             cmds << CDO_MULC_cmd.new(100)
           when ["K", "degC"]
             cmds << CDO_SUBC_cmd.new(-273.15)
+          when ["mmolC/m2/d", "kg m-2 s-1"]
+            cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
+          when ["uatm", "Pa"]
+            cmd << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"
           end          

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -236,7 +236,7 @@ module CMORizer
             #
             # these notes are available on the following link
             # https://notes.desy.de/F8hTyk3PRielZrVdZRtyaQ?view#Seamore-missing-features-FESOM1-and-2
-            cmd << CDO_MULC_cmd.new(0.101325)
+            cmds << CDO_MULC_cmd.new(0.101325)
           else
             raise "can not automatically convert unit from '#{from_unit}' to '#{to_unit}'"
           end          

--- a/lib/step.rb
+++ b/lib/step.rb
@@ -226,7 +226,8 @@ module CMORizer
             # In the CMIP6_Omon.json:fgco2 case, an additional sign change is necessary:
             # >0: into ocean -> >0: into atm: *-1
             # -> mult_factor = mult_factor*-1
-            cmds << CDO_MULC_cmd.new(-1.390127e-10)  # negative sign to correct into ocean or into atm
+            # COMMENT: For sign change use flip_sign function 
+            cmds << CDO_MULC_cmd.new(1.390127e-10)
           when ["uatm", "Pa"]
             # notes on how this factor was derived (by chrisdane "Christopher Danek")
             # e.g. recom variable: pCO2s => CMIP6_Omon.json: spco2


### PR DESCRIPTION
Potential solution to address issue #7 is to sanitise the variable name from user input source text. The variable name is kept as is but and extra line is added initialising the variable as a string with the same variable name. For instance, the following line produces an NameError (mis-treating `CO2f_day` as Ruby Constant as the name starts with a capital letter)

`cmorize CO2f_day => [fgco2_Omon]`

To overcome this, the following extra line is added:

```
CO2f_day = "CO2f_day"
cmorize CO2f_day => [fgco2_Omon]
```

The sanitisation process does the exact same thing at runtime so users do not have to explicitly provide this extra line.
 